### PR TITLE
Update README.md

### DIFF
--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -1,6 +1,6 @@
 # Deploying Upgradeable Smart Contracts
 
-Upgradeable smart contracts are deployed with Openzeppelin Defender to enable a deployment strategy that is more secure
+Upgradeable smart contracts are deployed with OpenZeppelin Defender to enable a deployment strategy that is more secure
 and also uses a multi-sig Safe wallet. When deploying using openzeppelin the `defender` profile in the `foundry.toml`
 file is used.
 


### PR DESCRIPTION
"Openzeppelin Defender" should be "OpenZeppelin Defender" to match the official capitalization of the product name.